### PR TITLE
feat: add template variable injection support

### DIFF
--- a/libs/config-parser.ts
+++ b/libs/config-parser.ts
@@ -38,6 +38,27 @@ export class ConfigParser {
           throw new Error('Invalid config: all files must be strings');
         }
       }
+      
+      // Validate vars if present
+      if (source.vars !== undefined) {
+        if (!Array.isArray(source.vars)) {
+          throw new Error('Invalid config: vars must be an array');
+        }
+        
+        for (const varItem of source.vars) {
+          if (!varItem || typeof varItem !== 'object') {
+            throw new Error('Invalid config: each var must be an object');
+          }
+          
+          if (!varItem.key || typeof varItem.key !== 'string') {
+            throw new Error('Invalid config: each var must have a key string');
+          }
+          
+          if (!varItem.value || typeof varItem.value !== 'string') {
+            throw new Error('Invalid config: each var must have a value string');
+          }
+        }
+      }
     }
   }
 }

--- a/libs/github-fetcher.ts
+++ b/libs/github-fetcher.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'fs';
 import { dirname, join } from 'path';
+import type { TemplateVar } from '../types.js';
 
 export class GitHubFetcher {
   async fetchFile(repo: string, ref: string, filePath: string): Promise<string> {
@@ -32,8 +33,26 @@ export class GitHubFetcher {
     }
   }
 
-  async downloadFile(repo: string, ref: string, filePath: string, localPath?: string): Promise<void> {
-    const content = await this.fetchFile(repo, ref, filePath);
+  private replaceVariables(content: string, vars?: TemplateVar[]): string {
+    if (!vars || vars.length === 0) {
+      return content;
+    }
+    
+    let result = content;
+    for (const variable of vars) {
+      // Replace all occurrences of the key with the value
+      result = result.replaceAll(variable.key, variable.value);
+    }
+    
+    return result;
+  }
+
+  async downloadFile(repo: string, ref: string, filePath: string, localPath?: string, vars?: TemplateVar[]): Promise<void> {
+    let content = await this.fetchFile(repo, ref, filePath);
+    
+    // Apply variable replacements if provided
+    content = this.replaceVariables(content, vars);
+    
     const targetPath = localPath || join('downloaded', repo, filePath);
     await this.saveFile(content, targetPath);
   }

--- a/repo-file-sync.ts
+++ b/repo-file-sync.ts
@@ -22,10 +22,14 @@ export class RepoFileSync {
   private async syncSource(source: RepoSource): Promise<void> {
     console.log(`\nSyncing from ${source.repo} (ref: ${source.ref})`);
     
+    if (source.vars && source.vars.length > 0) {
+      console.log(`  Template variables: ${source.vars.map(v => `${v.key} → ${v.value}`).join(', ')}`);
+    }
+    
     for (const file of source.files) {
       try {
         console.log(`  Downloading ${file}...`);
-        await this.fetcher.downloadFile(source.repo, source.ref, file);
+        await this.fetcher.downloadFile(source.repo, source.ref, file, undefined, source.vars);
       } catch (error) {
         console.error(`  Failed to download ${file}: ${error}`);
         throw error;

--- a/types.ts
+++ b/types.ts
@@ -1,7 +1,13 @@
+export interface TemplateVar {
+  key: string;
+  value: string;
+}
+
 export interface RepoSource {
   repo: string;
   ref: string;
   files: string[];
+  vars?: TemplateVar[];
 }
 
 export interface Config {


### PR DESCRIPTION
Implements template variable injection functionality as requested in #12.

This allows users to define template variables in their YAML configuration to replace text in downloaded files.

## Changes
- Add TemplateVar interface and optional vars field to RepoSource
- Enhance config parser with vars field validation
- Implement variable replacement in GitHubFetcher
- Update sync process to apply template variables during file download
- Add logging for template variable replacements

## Usage
```yaml
sources:
  - repo: owner/repo
    ref: main
    files: [README.md]
    vars:
      - key: PLACEHOLDER
        value: REPLACEMENT
```

Closes #12

Generated with [Claude Code](https://claude.ai/code)