### PR TITLE
fix: 既存ブランチ時に同期ファイルが破棄されるバグを修正

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -449,16 +449,10 @@ async function main() {
 
   if (branchExists) {
     log(`Found existing branch, will update with force push`);
-    // Checkout the existing remote branch
-    try {
-      await $`git checkout -B ${branchName} origin/${branchName}`.quiet();
-    } catch {
-      // If checkout fails, create from main
-      await createBranch(branchName);
-    }
-
-    // Reset to main and apply our changes
-    await $`git reset --hard main`.quiet();
+    // Create local branch from current HEAD (main with already-synced files)
+    // We force push anyway, so we don't need to checkout origin's version.
+    // Using reset --hard here would wipe out the synced files in the working tree.
+    await $`git checkout -b ${branchName}`.quiet();
 
     log("💾 Committing changes");
     await commitAndPush(COMMIT_MESSAGE, branchName, true);


### PR DESCRIPTION
## 背景

`repo-file-sync` を既に一度実行済みのリポジトリで再度実行すると、以下のエラーで失敗していた。

```
💾 Committing changes
##[error]Unexpected error: ShellError: Failed with exit code 1
```

実例: https://github.com/shoppingjaws/safe-webfetch/actions/runs/24342814088/job/71075732763

## 原因

同期対象ブランチ (`repo-file-sync`) がリモートに既に存在する場合のフローに問題があった。

1. ファイルを WORKSPACE に同期（working tree に変更が発生）
2. `git checkout -B <branch> origin/<branch>` で既存ブランチをチェックアウト
3. `git reset --hard main` を実行 ← **ここで同期済みの変更がすべて消える**
4. `git add . && git commit` → ステージするものがなく exit code 1 で失敗

どのみち force push するため origin の既存ブランチの内容を取り込む必要はなく、`reset --hard` は作業ツリーを破壊するだけだった。

## 変更内容

既存ブランチが存在する場合でも、現在の HEAD (同期済みファイルを含む main) からローカルブランチを作成し、そのままコミットして force push する方式に変更。これにより PR を維持しつつブランチを更新できる。